### PR TITLE
Update Material Design Lite CDN links

### DIFF
--- a/server/templates/base.html.j2
+++ b/server/templates/base.html.j2
@@ -9,7 +9,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:regular,bold,italic,thin,light,bolditalic,black,medium&amp;lang=en">
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
-    <link rel="stylesheet" href="https://code.getmdl.io/1.3.0/material.indigo-blue.min.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/material-design-lite/1.3.0/material.indigo-blue.min.css">
     <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='css/style.css') }}">
     <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='css/flash.css') }}">
     <script src="{{ url_for('static', filename='js/utils.js') }}"></script>
@@ -123,6 +123,6 @@
       </main>
     </div>
 
-    <script src="https://code.getmdl.io/1.3.0/material.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/material-design-lite/1.3.0/material.min.js"></script>
   </body>
 </html>

--- a/server/templates/seat.html.j2
+++ b/server/templates/seat.html.j2
@@ -9,7 +9,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:regular,bold,italic,thin,light,bolditalic,black,medium&amp;lang=en">
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
-    <link rel="stylesheet" href="https://code.getmdl.io/1.3.0/material.indigo-blue.min.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/material-design-lite/1.3.0/material.indigo-blue.min.css">
     <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='css/style.css') }}">
     <title>{% block title %}{{ room.display_name }} {{seat.display_name}}{% endblock %}</title>
   </head>
@@ -28,6 +28,6 @@
         {% endblock %}
       </main>
     </div>
-    <script src="https://code.getmdl.io/1.3.0/material.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/material-design-lite/1.3.0/material.min.js"></script>
   </body>
 </html>


### PR DESCRIPTION
This is a temporary workaround to address #84 using the Cloudflare links from https://github.com/google/material-design-lite/issues/5464#issuecomment-3840713018. A long-term fix is needed since I'm not sure how long these alternative links will work.

I don't have the repo setup locally, but I tested this using inspect element on https://seating.eecs.cloud.