### PR TITLE
Create shareable links for all seats, even if student is not assigned

### DIFF
--- a/server/templates/macros.html.j2
+++ b/server/templates/macros.html.j2
@@ -70,6 +70,9 @@
               <img class="photo" src="{{ url_for('student_photo', exam_student=(room.exam, seat.assignment.student)) }}" alt="photo for: {{ seat.assignment.student.name }}"/>
             <br>{{ seat.assignment.student.sid }}
           {% endif %}
+          {% if staff %}
+            <br><a target="_blank" href="{{ url_for('student_single_seat', seat_id=seat.id) }}">Shareable Link</a>
+          {% endif %}
         </div>
       {% endfor %}
 
@@ -128,6 +131,9 @@
           <br>
             <img class="photo" src="{{ url_for('student_photo', exam_student=(room.exam, seat.assignment.student)) }}" alt="photo for: {{ seat.assignment.student.name }}"/>
           <br>{{ seat.assignment.student.sid }}
+        {% endif %}
+        {% if staff %}
+          <br><a target="_blank" href="{{ url_for('student_single_seat', seat_id=seat.id) }}">Shareable Link</a>
         {% endif %}
       </div>
       {% if loop.last %}

--- a/server/templates/macros.html.j2
+++ b/server/templates/macros.html.j2
@@ -70,12 +70,8 @@
               <img class="photo" src="{{ url_for('student_photo', exam_student=(room.exam, seat.assignment.student)) }}" alt="photo for: {{ seat.assignment.student.name }}"/>
             <br>{{ seat.assignment.student.sid }}
           {% endif %}
-          {% if staff %}
-            <br><a target="_blank" href="{{ url_for('student_single_seat', seat_id=seat.id) }}">Shareable Link</a>
-          {% endif %}
         </div>
       {% endfor %}
-
       {% for seat in room.movable_seats_by_attribute[attr] %}
         {% if seat.id and seat.id == highlight_seat_id %}
           <span><strong>(YOUR WILL USE A SEAT FROM THIS CATEGORY)</strong></span>
@@ -105,20 +101,22 @@
       {% if loop.first %}
         <div class="seat-label" style="left:{{ x + 30 }}px;top:{{ y }}px">{{ seat.name }}</div>
       {% endif %}
-      {% if staff and seat.assignment and not remove_link %}
-      <a href="{{ url_for('student', exam_student=(exam, seat.assignment.student)) }}">
-      {% endif %}
-        {% if seat.id and seat.id == highlight_seat_id %}
+      {% if seat.id and seat.id == highlight_seat_id %}
           {% set class = 's seat highlight' %}
         {% elif staff and seat.assignment %}
           {% set class = 's seat occupied' %}
         {% else %}
           {% set class = 's seat' %}
         {% endif %}
-        <div id="{{ seat.id }}" class="{{ class }}" style="left:{{ x }}px;top:{{ y }}px"></div>
-      {% if staff and seat.assignment and not remove_link %}
-      </a>
-      {% endif %}
+        {% if staff and seat.assignment and not remove_link %}
+        <a href="{{ url_for('student', exam_student=(exam, seat.assignment.student)) }}" target="_blank">
+        {% elif staff %}
+        <a href="{{ url_for('student_single_seat', seat_id=seat.id) }}" target="_blank">
+        {% endif %}
+          <div id="{{ seat.id }}" class="{{ class }}" style="left:{{ x }}px;top:{{ y }}px"></div>
+        {% if staff %}
+        </a>
+        {% endif %}
       <div class="seat-tooltip mdl-tooltip mdl-tooltip--large" for="{{ seat.id }}">
         {{ seat.name }}
         {% if show_attributes %}
@@ -132,9 +130,6 @@
             <img class="photo" src="{{ url_for('student_photo', exam_student=(room.exam, seat.assignment.student)) }}" alt="photo for: {{ seat.assignment.student.name }}"/>
           <br>{{ seat.assignment.student.sid }}
         {% endif %}
-        {% if staff %}
-          <br><a target="_blank" href="{{ url_for('student_single_seat', seat_id=seat.id) }}">Shareable Link</a>
-        {% endif %}
       </div>
       {% if loop.last %}
         <div class="seat-label" style="left:{{ x - 50 }}px;top:{{ y }}px">{{ seat.name }}</div>
@@ -144,6 +139,7 @@
   </div>
   </div>
   <h6>Back</h6>
+  <h6>Click on any assigned seat (blue) to view student details. Clicking on an unoccupied seat will lead you to a shareable link for that seat.</h6>
   {% endif %}
 </div>
 {% endif %}

--- a/server/templates/macros.html.j2
+++ b/server/templates/macros.html.j2
@@ -129,7 +129,7 @@
           <br>
             <img class="photo" src="{{ url_for('student_photo', exam_student=(room.exam, seat.assignment.student)) }}" alt="photo for: {{ seat.assignment.student.name }}"/>
           <br>{{ seat.assignment.student.sid }}
-        {% endif %}
+        {% endif %} -m 
       </div>
       {% if loop.last %}
         <div class="seat-label" style="left:{{ x - 50 }}px;top:{{ y }}px">{{ seat.name }}</div>
@@ -139,7 +139,9 @@
   </div>
   </div>
   <h6>Back</h6>
+  {% if staff %}
   <h6>Click on any assigned seat (blue) to view student details. Clicking on an unoccupied seat will lead you to a shareable link for that seat.</h6>
+  {% endif %}
   {% endif %}
 </div>
 {% endif %}


### PR DESCRIPTION
resolving issue #73 by opening shareable link in new tab whenever a seat is clicked on. See images below:
<img width="1315" height="909" alt="Screenshot 2026-03-30 at 4 05 38 PM" src="https://github.com/user-attachments/assets/bd69a9c5-7ad5-4d47-942d-b5c3ea609bfb" />

<img width="1325" height="829" alt="Screenshot 2026-03-30 at 4 05 52 PM" src="https://github.com/user-attachments/assets/3502c87b-53aa-49ef-a136-417f8c10a1f2" />
